### PR TITLE
Raise requirement for satooshi/php-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
-  - '5.5'
-  - '5.6'
   - '7.0'
+  - '7.1'
 
 before_script:
  - wget http://getcomposer.org/composer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - '5.4'
   - '5.5'
   - '5.6'
+  - '7.0'
 
 before_script:
  - wget http://getcomposer.org/composer.phar

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
         "psr-4": {"": "src/"}
     },
     "require": {
-        "satooshi/php-coveralls": "^1"
+        "satooshi/php-coveralls": "dev-master"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "autoload": {
         "psr-4": {"": "src/"}
     },
-    "require": {
+    "require-dev": {
+        "phpunit/phpunit": "^6.2",
         "satooshi/php-coveralls": "dev-master"
     }
 }

--- a/tests/Seboettg/Collection/Test/ArrayListTest.php
+++ b/tests/Seboettg/Collection/Test/ArrayListTest.php
@@ -11,11 +11,11 @@
 
 namespace Seboettg\Collection\Test;
 
-
+use PHPUnit\Framework\TestCase;
 use Seboettg\Collection\ArrayList;
 use Seboettg\Collection\Comparable;
 
-class ArrayListTest extends \PHPUnit_Framework_TestCase
+class ArrayListTest extends TestCase
 {
 
     /**
@@ -134,9 +134,8 @@ class ArrayListTest extends \PHPUnit_Framework_TestCase
 
     public function testHasKey()
     {
-        $this->numeratedArrayList->hasKey(0);
-        $this->hashMap->hasKey("c");
-
+        $this->assertTrue($this->numeratedArrayList->hasKey(0));
+        $this->assertTrue($this->hashMap->hasKey("c"));
     }
 
     public function testHasValue()

--- a/tests/Seboettg/Collection/Test/CollectionsTest.php
+++ b/tests/Seboettg/Collection/Test/CollectionsTest.php
@@ -11,12 +11,13 @@
 
 namespace Seboettg\Collection\Test;
 
+use PHPUnit\Framework\TestCase;
 use Seboettg\Collection\ArrayList;
 use Seboettg\Collection\Collections;
 use Seboettg\Collection\Comparable;
 use Seboettg\Collection\Comparator;
 
-class CollectionsTest extends \PHPUnit_Framework_TestCase
+class CollectionsTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
This replaces the implicit dependency for guzzle/guzzle which is now
abandoned.

Fixes #1 