### PR TITLE
Fix notices about some ArrayAccessTrait methods for PHP 8.1+

### DIFF
--- a/src/ArrayList/ArrayAccessTrait.php
+++ b/src/ArrayList/ArrayAccessTrait.php
@@ -23,6 +23,7 @@ trait ArrayAccessTrait
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->array);
@@ -35,6 +36,7 @@ trait ArrayAccessTrait
      *
      * @return mixed Can return all value types.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->array[$offset]) ? $this->array[$offset] : null;
@@ -46,6 +48,7 @@ trait ArrayAccessTrait
      * @param mixed $offset The offset to assign the value to.
      * @param mixed $value The value to set.
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->array[$offset] = $value;
@@ -58,6 +61,7 @@ trait ArrayAccessTrait
      * @param mixed $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->array[$offset]);
@@ -68,6 +72,7 @@ trait ArrayAccessTrait
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset The offset to unset.
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->array[$offset]);
@@ -76,6 +81,7 @@ trait ArrayAccessTrait
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->array);

--- a/tests/CollectionsTest.php
+++ b/tests/CollectionsTest.php
@@ -25,8 +25,7 @@ class CollectionsTest extends TestCase
      */
     private $numeratedArrayList;
 
-    #[\ReturnTypeWillChange]
-    public function setUp()
+    public function setUp(): void
     {
         $this->numeratedArrayList = new ArrayList(
             new Element("a", "aa"),

--- a/tests/CollectionsTest.php
+++ b/tests/CollectionsTest.php
@@ -25,6 +25,7 @@ class CollectionsTest extends TestCase
      */
     private $numeratedArrayList;
 
+    #[\ReturnTypeWillChange]
     public function setUp()
     {
         $this->numeratedArrayList = new ArrayList(

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -27,7 +27,7 @@ class QueueTest extends TestCase
      */
     protected $queue;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->queue = new Queue();
 

--- a/tests/StackTest.php
+++ b/tests/StackTest.php
@@ -25,7 +25,7 @@ class StackTest extends TestCase
      */
     protected $stack;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stack = new Stack();
     }


### PR DESCRIPTION
I'm using PHP 8.1.2 and PHP 8.1.7 versions with your great library.
I found a few small issues like:
`Deprecated function: Return type of Seboettg\Collection\ArrayList::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 23 of /var/www/vendor/seboettg/collection/src/ArrayList.php).`

To fix it and have compatibility with older PHP versions we just need to use #[\ReturnTypeWillChange] attribute for a number of ArrayAccessTrait methods.